### PR TITLE
Setup file of accelerate-cuda does not run configure

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,4 +1,4 @@
 #! /usr/bin/env runhaskell
 
 import Distribution.Simple
-main = defaultMain
+main = defaultMainWithHooks autoconfUserHooks


### PR DESCRIPTION
It's fine if you use `cabal configure` because `Build-Type` is set to `Configure`. But manually running `Setup configure` (as some Linux distributions do) fails. This patch fixes it.
