### PR TITLE
Fixed issue with warp synchronization in foldAll kernel.

### DIFF
--- a/Data/Array/Accelerate/CUDA/CodeGen/Reduction.hs
+++ b/Data/Array/Accelerate/CUDA/CodeGen/Reduction.hs
@@ -654,11 +654,13 @@ reduceBlockTree dev fun@(CUFun2 _ _ f) x0 x1 sdata n
       -- warp has read in their data for this step.
       --
       | i > warpSize dev
-      = [cstm| if ( threadIdx.x + $int:i < $exp:n ) {
-                   __syncthreads();
+      = [cstm| __syncthreads(); |]
+        : [cstm| if ( threadIdx.x + $int:i < $exp:n ) {
                    $items:(x0 .=. sdata ("threadIdx.x + " ++ show i))
                    $items:(x1 .=. f x1 x0)
-                   __syncthreads();
+                 } |]
+        : [cstm| __syncthreads(); |]
+        : [cstm| if ( threadIdx.x + $int:i < $exp:n ) {
                    $items:(sdata "threadIdx.x" .=. x1)
                } |]
       : rest


### PR DESCRIPTION
This change fixes the issue documented in https://github.com/AccelerateHS/accelerate/issues/123.

The issue was that accelerate-cuda was generating code that relied on __syncthreads() statements made inside conditionals. These conditionals sometimes evaluated differently for different threads in the same warp. In this case, __syncthreads() was not guaranteed to work.

I'm not a CUDA/C expert, so I can't say that this code is the cleanest or most efficient way to accomplish the desired change. But I have confirmed that it performs correctly on the test program described in https://github.com/AccelerateHS/accelerate/issues/123 with my computer setup.
