### PR TITLE
Win32 compilation fix

### DIFF
--- a/Data/Array/Accelerate/CUDA/Compile.hs
+++ b/Data/Array/Accelerate/CUDA/Compile.hs
@@ -79,7 +79,7 @@ import System.Time
 #if   defined(UNIX)
 import System.Posix.Process
 #elif defined(WIN32)
-import System.Win32.Process
+import System.Win32.Process hiding (ProcessHandle)
 #else
 #error "I don't know what operating system I am"
 #endif


### PR DESCRIPTION
Without this fix, compilation on Windows fails:
```
[34 of 37] Compiling Data.Array.Accelerate.CUDA.Compile ( Data\Array\Accelerate\CUDA\Compile.hs, dist\dist-sand

Data\Array\Accelerate\CUDA\Compile.hs:667:12:
    Ambiguous occurrence `ProcessHandle'
    It could refer to either `System.Process.ProcessHandle',
                             imported from `System.Process' at Data\Array\Accelerate\CUDA\Compile.hs:62:1-21
                             (and originally defined in `System.Process.Internals')
                          or `System.Win32.Process.ProcessHandle',
                             imported from `System.Win32.Process' at Data\Array\Accelerate\CUDA\Compile.hs:82:1
```