### PR TITLE
Removed time consuming performGC call

### DIFF
--- a/Data/Array/Accelerate/CUDA/State.hs
+++ b/Data/Array/Accelerate/CUDA/State.hs
@@ -43,7 +43,6 @@ import Control.Exception                                ( catch, bracket_ )
 import Control.Monad.Trans                              ( MonadIO )
 import Control.Monad.Reader                             ( MonadReader, ReaderT(..), runReaderT )
 import Control.Monad.State.Strict                       ( MonadState, StateT(..), evalStateT )
-import System.Mem                                       ( performGC )
 import System.IO.Unsafe                                 ( unsafePerformIO )
 import Foreign.CUDA.Driver.Error
 import qualified Foreign.CUDA.Driver                    as CUDA
@@ -85,7 +84,7 @@ evalCUDA !ctx !acc =
   \e -> $internalError "unhandled" (show (e :: CUDAException))
   where
     setup       = push ctx
-    teardown    = pop >> performGC
+    teardown    = pop
     action      = evalStateT (runReaderT (runCIO acc) ctx) theState
 
 


### PR DESCRIPTION
Hi! 
Regarding to https://github.com/AccelerateHS/accelerate/issues/227 and my answer here  http://stackoverflow.com/a/28084927/1641629 `accelerate` is working slow under `ghci` because of `performGC` call, which from my tests takes more than `130ms`. I think we can relay on ghc garbage collector to clean memory on its own and we should not force it to do it on cleanup.