### PR TITLE
Fixing non deterministic error: CUDA Exception: invalid device context

### DIFF
--- a/Data/Array/Accelerate/CUDA.hs
+++ b/Data/Array/Accelerate/CUDA.hs
@@ -262,9 +262,10 @@ runAsync a
 -- expression. See the CUDA C Programming Guide (G.1) for more information.
 --
 runWith :: Arrays a => Context -> Acc a -> a
-runWith ctx a
-  = unsafePerformIO
-  $ evaluate (runAsyncWith ctx a) >>= wait
+runWith ctx a = unsafePerformIO execute
+  where
+    !acc    = convertAccWith config a
+    execute = evalCUDA ctx (compileAcc acc >>= dumpStats >>= executeAcc >>= collect)
 
 
 -- | As 'runWith', but execute asynchronously. Be sure not to destroy the context,


### PR DESCRIPTION
Hello!

I was talking before in this thread (https://github.com/AccelerateHS/accelerate/issues/227#issuecomment-73051526) about non deterministic CUDA error. It looks like removing `async` call in `Data.Array.Accelerate.CUDA.runWith` resolves this problem. 

Before that fix, in 20 tests error occured 11 times on my PC. Now I have executed it 1000 times and everything was fine.