### PR TITLE
updated the transformers dependency in the .cabal file

### DIFF
--- a/accelerate-cuda.cabal
+++ b/accelerate-cuda.cabal
@@ -105,7 +105,7 @@ Library
                         srcloc                  >= 0.2,
                         text                    >= 0.11,
                         template-haskell        >= 2.2,
-                        transformers            >= 0.2,
+                        transformers            >= 0.4,
                         unordered-containers    >= 0.1.4
 
   if os(windows)


### PR DESCRIPTION
while working on a tiny feature for accelerate-cuda I've noticed there is a problems with one of the dependencies
Data.Array.Accelerate.CUDA.Execute imports evalContT that was added in transformers 0.4, and the dependency was for transformers >= 0.2
for clean builds that shouldn't be a problem unless transformers < 0.4.x is arleady installed