### PR TITLE
an option to set the include paths for nvcc using env vars

### DIFF
--- a/Data/Array/Accelerate/CUDA/Compile.hs
+++ b/Data/Array/Accelerate/CUDA/Compile.hs
@@ -55,6 +55,7 @@ import Data.Bits
 import Data.Maybe
 import Data.Monoid
 import System.Directory
+import System.Environment                                       ( lookupEnv )
 import System.Exit                                              ( ExitCode(..) )
 import System.FilePath
 import System.IO
@@ -559,10 +560,13 @@ compileFlags :: FilePath -> CIO [String]
 compileFlags cufile = do
   CUDA.Compute m n      <- CUDA.computeCapability `fmap` asks deviceProperties
   ddir                  <- liftIO getDataDir
+  incdir                <- liftIO $ lookupEnv "ACCELERATEHS_NVCC_INC_PATH"
+  addincdir             <- liftIO $ lookupEnv "ACCELERATEHS_NVCC_ADD_INC_PATH"
   warnings              <- liftIO $ (&&) <$> D.queryFlag D.dump_cc <*> D.queryFlag D.verbose
   debug                 <- liftIO $ D.queryFlag D.debug_cc
   return                $  filter (not . null) $
-    [ "-I", ddir </> "cubits"
+    [ "-I", fromMaybe (ddir </> "cubits") incdir
+    , maybe "" (mappend "-I") addincdir
     , "-arch=sm_" ++ show m ++ show n
     , "-cubin"
 --    , "--restrict"    -- requires nvcc >= 5.0


### PR DESCRIPTION
While trying to run some executables on a clean system it hit me that the app requires accelerate's headers in run-time to compile the generated kernels, thus making me redistribute the headers with the software.
I've looked through the docs and the code and haven't found any way to let nvcc know where it should look for the headers, so I took the liberty of adding that feature.
The solution is simple: there are two environment variables, one to override the default search location (if, for some wacky reason, someone would like to override the accelerate headers), and a second var to add a new path (for custom headers)

A few questions regarding this topic:
* first and foremost, the licensing issues: I've never had the necessity to redistribute someone else's work, so I'm not sure what I'm supposed to do about this part
* is it plausible to use environment variables? after giving it a bit of thought it seemed like the best solution
* should I add the information about those variables to any kind of documentation, e.g. in the code (I've seen the flags for debugging documented that way)
* (sudden realisation) someone might want to add more than one custom search path; should I rewrite this to use separators like ":" to define multiple paths?